### PR TITLE
computeSARParams and standardization

### DIFF
--- a/funcs.cpp
+++ b/funcs.cpp
@@ -14,8 +14,8 @@ const int dimX = -1;
 const int dimY = -1;
 
 //dx, dy, pointsX, pointsY, not shared, should be fine
-extern int SARStepXUI = -1;
-extern int SARStepYUI = -1;
+extern int SARstepXUI = -1;
+extern int SARstepYUI = -1;
 extern int pointsX = -1;
 extern int pointsY = -1;
 
@@ -36,17 +36,17 @@ void setDirectionYDown()
     digitalWrite(dirPiny, HIGH); //low = up
 }
 
-void move_x(int SARStepX)
+void move_x(int SARstepX)
 {
-    for(int i = 0; i < SARStepX; i++)
+    for(int i = 0; i < SARstepX; i++)
     {
         step_x();
     }
 }
 
-void move_y(int SARStepY)
+void move_y(int SARstepY)
 {
-    for(int i = 0; i < SARStepY; i++)
+    for(int i = 0; i < SARstepY; i++)
     {
         step_y();
     }
@@ -54,8 +54,8 @@ void move_y(int SARStepY)
 
 void resetSARParams()
 {
-    SARStepXUI = -1;
-    SARStepYUI = -1;
+    SARstepXUI = -1;
+    SARstepYUI = -1;
     pointsY = -1;
     pointsY = -1;
 }
@@ -68,9 +68,9 @@ void initUI()
     {
         if(Serial.available() > 0)
         {
-            SARStepXUI = Serial.parseInt();
-            SARStepYUI = Serial.parseInt();
-            valid = initUIValidation(SARStepXUI, SARStepYUI);
+            SARstepXUI = Serial.parseInt();
+            SARstepYUI = Serial.parseInt();
+            valid = initUIValidation(SARstepXUI, SARstepYUI);
             if(valid == true)
             {
                 //computation for pointsY and pointsY
@@ -85,10 +85,10 @@ void initUI()
         }
     }
     Serial.print("SAR dx SAR dy pointsY pointsY are: \n");
-    Serial.print(SARStepXUI); Serial.print(" "); 
-    Serial.print(SARStepXUI); Serial.print(" ");
-    Serial.print(SARStepXUI); Serial.print(" ");
-    Serial.print(SARStepXUI); Serial.print(" \n");
+    Serial.print(SARstepXUI); Serial.print(" "); 
+    Serial.print(SARstepXUI); Serial.print(" ");
+    Serial.print(SARstepXUI); Serial.print(" ");
+    Serial.print(SARstepXUI); Serial.print(" \n");
 }
 
 void stopSync() //arbitary delay rn
@@ -120,9 +120,16 @@ void step_y()
 /*
 
 */
-void computeSARParams()
+void computeSARParams(int SARstepX, int SARstepY)
 {
-    
+    // output is updated:
+        // SARstepXUI , SARstepYUI , pointsX , pointsY
+    SARstepXUI = SARstepX;
+    SARstepYUI = SARstepY;
+
+    // Points = cm / cm
+    pointsX = dimX / SARstepX;
+    pointsY = dimY / SARstepY;
 }
 
 /*

--- a/funcs.cpp
+++ b/funcs.cpp
@@ -122,8 +122,14 @@ void step_y()
 */
 void computeSARParams(int SARstepX, int SARstepY)
 {
-    // output is updated:
+    // Error handling
+    if (!initUIValidation(SARstepX, SARstepY)){
+        return;
+    }
+
+    // Updates:
         // SARstepXUI , SARstepYUI , pointsX , pointsY
+
     SARstepXUI = SARstepX;
     SARstepYUI = SARstepY;
 
@@ -135,9 +141,24 @@ void computeSARParams(int SARstepX, int SARstepY)
 /*
 
 */
-bool initUIValidation(int dx, int dy)
+bool initUIValidation(int SARstepX , int SARstepY)
 {
+    // Check:
+        // Step size > micro step size
+        // Step size < dimensions
+        // TODO: others?
+        
+    // Step size > micro step size
+    if (SARstepX < microStep){return 0;}
+    if (SARstepY < microStep){return 0;}
+    
+    // Step size < dimensions
+    if (SARstepX > dimX){return 0;}
+    if (SARstepY > dimY){return 0;}
 
+
+    // If all is good, then return true
+    return 1;
 }
 
 /*

--- a/funcs.h
+++ b/funcs.h
@@ -21,21 +21,21 @@ extern const int dimX;
 extern const int dimY;
 
 //dx, dy, pointsX, pointsY, not shared, should be fine
-extern int SARStepXUI;
-extern int SARStepYUI;
+extern int SARstepXUI;
+extern int SARstepYUI;
 extern int pointsX;
 extern int pointsY;
 
 //arbitary delay for now till get radar params for sync
 extern const int arbitaryDelay; //1s
 
-void move_x(int SARStepX);
+void move_x(int SARstepX);
 
 //TODO
 void step_x();
 void step_y();
 
-void move_y(int SARStepY);
+void move_y(int SARstepY);
 
 //TODO
 void computeSARParams();


### PR DESCRIPTION
Filled computeSARParams() function. Updated all SARStepXUI and SARStepYUI to SARstepXUI and SARstepYUI to match documentation. Also the lowercase s makes it easier to read.